### PR TITLE
Replace in-memory activities with SQLite + SQLModel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+sqlmodel
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -11,6 +11,11 @@ from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+from sqlmodel import Session, select
+
+from src.db import get_engine, create_db_and_tables, Activity, Signup
+
+
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
@@ -19,63 +24,9 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Initialize DB and engine
+engine = get_engine()
+create_db_and_tables(engine)
 
 
 @app.get("/")
@@ -85,48 +36,61 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with Session(engine) as session:
+        activities = session.exec(select(Activity)).all()
+        result = {}
+        for a in activities:
+            # load participants
+            participants = session.exec(select(Signup).where(Signup.activity_id == a.id)).all()
+            result[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": [p.email for p in participants]
+            }
+        return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with Session(engine) as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participants = session.exec(select(Signup).where(Signup.activity_id == activity.id)).all()
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        # Validate student is not already signed up
+        if any(p.email == email for p in participants):
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        # Validate capacity
+        if len(participants) >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
+
+        signup = Signup(activity_id=activity.id, email=email)
+        session.add(signup)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with Session(engine) as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        signup = session.exec(
+            select(Signup).where((Signup.activity_id == activity.id) & (Signup.email == email))
+        ).first()
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+        # Validate student is signed up
+        if not signup:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(signup)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,116 @@
+from typing import List, Optional
+import os
+
+from sqlmodel import SQLModel, Field, Relationship, create_engine, Session, select
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./activities.db")
+
+
+class Signup(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    activity_id: int = Field(foreign_key="activity.id")
+    email: str
+    activity: Optional["Activity"] = Relationship(back_populates="participants")
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: int = 0
+    participants: List[Signup] = Relationship(back_populates="activity")
+
+
+def create_db_and_tables(engine=None):
+    if engine is None:
+        engine = create_engine(DATABASE_URL, echo=False)
+    SQLModel.metadata.create_all(engine)
+    # seed data if empty
+    with Session(engine) as session:
+        count = session.exec(select(Activity)).first()
+        if count is None:
+            seed_activities(session)
+
+
+def get_engine():
+    # SQLite needs check_same_thread=False for multi-threaded use by testclient
+    connect_args = {}
+    if DATABASE_URL.startswith("sqlite"):
+        connect_args = {"check_same_thread": False}
+    return create_engine(DATABASE_URL, echo=False, connect_args=connect_args)
+
+
+def seed_activities(session: Session):
+    # Mirror previous in-memory seed
+    seeds = {
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        },
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        },
+        "Basketball Team": {
+            "description": "Practice and play basketball with the school team",
+            "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        },
+        "Art Club": {
+            "description": "Explore your creativity through painting and drawing",
+            "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        },
+        "Drama Club": {
+            "description": "Act, direct, and produce plays and performances",
+            "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        },
+        "Math Club": {
+            "description": "Solve challenging problems and participate in math competitions",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+            "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        },
+        "Debate Team": {
+            "description": "Develop public speaking and argumentation skills",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 12,
+            "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        },
+    }
+
+    for name, info in seeds.items():
+        activity = Activity(
+            name=name,
+            description=info.get("description"),
+            schedule=info.get("schedule"),
+            max_participants=info.get("max_participants", 0),
+        )
+        session.add(activity)
+        session.commit()
+        session.refresh(activity)
+        for email in info.get("participants", []):
+            signup = Signup(activity_id=activity.id, email=email)
+            session.add(signup)
+        session.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+import os
+
+from src.app import app
+
+
+client = TestClient(app)
+
+
+def test_get_activities_returns_seeded_activities():
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    data = resp.json()
+    # some seeded activity names should exist
+    assert "Chess Club" in data
+    assert isinstance(data["Chess Club"]["participants"], list)
+
+
+def test_signup_and_prevent_duplicate():
+    email = "tester@example.com"
+    activity = "Chess Club"
+    # ensure not signed up yet
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp.status_code == 200
+    # duplicate signup should fail
+    resp2 = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp2.status_code == 400
+
+
+def test_unregister():
+    email = "tester2@example.com"
+    activity = "Programming Class"
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp.status_code == 200
+    # now unregister
+    resp2 = client.delete(f"/activities/{activity}/unregister", params={"email": email})
+    assert resp2.status_code == 200


### PR DESCRIPTION
This PR replaces the in-memory `activities` store with a persistent SQLite database using SQLModel.

Changes:
- Add `src/db.py` with `Activity` and `Signup` models, DB engine and seeding logic.
- Wire `src/app.py` to use the DB for listing activities, signup and unregister endpoints.
- Add tests in `tests/test_db.py` and update `requirements.txt`.

Tests: basic tests added for listing activities, signing up, preventing duplicate signups, and unregistering. 